### PR TITLE
Make company list button more obvious

### DIFF
--- a/source/components/home/about/about.js
+++ b/source/components/home/about/about.js
@@ -46,7 +46,7 @@ class About extends Component {
                                     Join us for ACM Career Week on September 26th for our Startup Fair and on September 27th for our Career Fair! Both the Startup and Career Fair will run from 10am to 4pm.
                                     Last year, almost 2000 students interacted with 27 of the best tech companies around. Come dressed casually after class to interact with recruiters, learn about the companies, and apply for internships.
                                     <br/><br/>
-                                    <a href="http://reflectionsprojections.org/companies" className="anchor-look-like-normal">Click here to view the list of companies attending!</a><br/>
+                                    <a href="http://reflectionsprojections.org/companies" className="About__registerButton caps btn btn-default">Company list and fair maps</a><br/>
                                     {/* View <a href="http://reflectionsprojections.org/companies" className="anchor-look-like-normal">our Startup Fair map here</a> and <a href="http://reflectionsprojections.org/companies" className="anchor-look-like-normal">our Career Fair map here.</a> */}
                                 </span>
                                 </Tab>

--- a/source/components/home/about/styles.scss
+++ b/source/components/home/about/styles.scss
@@ -20,7 +20,7 @@
     }
 
     &__leftTabs, &__rightTabs {
-        a:not(.anchor-look-like-normal) {
+        a:not(.anchor-look-like-normal):not(.About__registerButton) {
             background-color: rgba(0,0,0,0) !important;
             border: none !important;
             padding: 1em 1em 1em 0em !important;


### PR DESCRIPTION
This PR makes a quick change that renders the career fair company list as a large button, similar to the registration and schedule buttons.